### PR TITLE
Fix bad tx count when serializing the block.

### DIFF
--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -77,17 +77,7 @@ var BlockTemplate = module.exports = function BlockTemplate(jobId, rpcData, extr
     // join the header and txs together
     this.serializeBlock = function(header, soln){
 
-        var txCount = this.txCount.toString(16);
-        if (Math.abs(txCount.length % 2) == 1) {
-          txCount = "0" + txCount;
-        }
-        
-        if (this.txCount <= 0x7f){
-            var varInt = new Buffer(txCount, 'hex');
-        }
-        else if (this.txCount <= 0x7fff){
-            var varInt = new Buffer.concat([Buffer('FD', 'hex'), new Buffer(txCount, 'hex')]);
-        }
+        var txCount = util.varIntBuffer(this.txCount);
         
         buf = new Buffer.concat([
             header,


### PR DESCRIPTION
Looks like the original logic can't handle it properly when there are 128 to 256 transactions: it will produce an invalid block which can't be decoded by the core client.

I didn't test the code. Please don't merge this before fully tested.